### PR TITLE
sls: add support for using system groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ make PREFIX=/usr install
 ## Usage
 
 sls authentication system is based on file metadata. To authenticate you need
-to change group of a file to corresponding group of user. Pretty nifty, huh?
+to change the group of sls to a group you are in. Pretty nifty, huh?
 
 ### Example
 
 ```sh
 # change <grp> to group of user (see: id -gn)
 chown root:<grp> path/to/sls
+chmod gu+s       path/to/sls
+
+# or make the owning group wheel, so the users in wheel can authenticate
+chown root:wheel path/to/sls
 chmod gu+s       path/to/sls
 ```
 


### PR DESCRIPTION
Hey illiliti,

I don't know what your opinion would be on adding "system group" support to `sls`, but I find this functionality quite useful myself. This adds a new function `checkgroups()` which basically verifies whether the calling user is part of the owning group. 

This way
- multiple users under the same group can use `sls`
- `sls` can be packaged under the traditional `wheel` group (or any other system group) so that users don't have to change the ownership after installation or an update.