### PR TITLE
don't use $< outside of inference rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -D_GNU_SOURCE \
 all: ssu
 
 ssu: ssu.o
-	${CC} ${XCFLAGS} -o $@ $< ${LDFLAGS}
+	${CC} ${XCFLAGS} -o $@ $@.o ${LDFLAGS}
 
 .c.o:
 	${CC} ${XCFLAGS} -c -o $@ $<


### PR DESCRIPTION
POSIX only specifies $< as being set in inference rules, and it doesn't work for bmake